### PR TITLE
add version of conditional aae

### DIFF
--- a/moses/aae/config.py
+++ b/moses/aae/config.py
@@ -5,6 +5,8 @@ def get_parser():
     parser = argparse.ArgumentParser()
 
     model_arg = parser.add_argument_group('Model')
+    model_arg.add_argument('--conditional_model', type=bool, default=False,
+                           help='If true to learn given conditions')
     model_arg.add_argument('--embedding_size', type=int, default=32,
                            help='Embedding size in encoder and decoder')
     model_arg.add_argument('--encoder_hidden_size', type=int, default=380,
@@ -25,11 +27,15 @@ def get_parser():
                            help='Size of latent vectors')
     model_arg.add_argument('--discriminator_layers', nargs='+', type=int, default=[640, 256],
                            help='Numbers of features for linear layers in discriminator')
+    model_arg.add_argument('--labels_size', type=int, default=167,
+                           help='Size of labels')
+    model_arg.add_argument('--labels_embedding_size', type=int, default=50,
+                           help='Size of labels after embedding')
 
     train_arg = parser.add_argument_group('Training')
     train_arg.add_argument('--pretrain_epochs', type=int, default=0,
                            help='Number of epochs for autoencoder pretraining')
-    train_arg.add_argument('--train_epochs', type=int, default=25,
+    train_arg.add_argument('--train_epochs', type=int, default=20,
                            help='Number of epochs for autoencoder training')
     train_arg.add_argument('--n_batch', type=int, default=128,
                            help='Size of batch')
@@ -41,6 +47,10 @@ def get_parser():
                            help='Multiplicative factor of learning rate decay')
     train_arg.add_argument('--n_jobs', type=int, default=1,
                            help='Number of threads')
+    train_arg.add_argument('--d_threshold', type=float, default=0.5,
+                           help='If loss of discriminator lower than the threshold, discriminator stop improving')
+    train_arg.add_argument('--g_threshold', type=float, default=0.8,
+                           help='If loss of discriminator is higher than the threshold, generator stop improving')
 
     return parser
 

--- a/moses/aae/trainer.py
+++ b/moses/aae/trainer.py
@@ -7,6 +7,9 @@ from torch.utils.data import DataLoader
 from torch.nn.utils.rnn import pad_sequence
 from collections import OrderedDict
 
+import numpy as np
+from rdkit import Chem
+from rdkit.Chem import MACCSkeys
 
 __all__ = ['AAETrainer']
 
@@ -23,8 +26,11 @@ class AAETrainer:
 
         postfix = {'loss': 0}
 
-        for i, (encoder_inputs, decoder_inputs, decoder_targets) in enumerate(tqdm_data):
+        for i, (encoder_inputs, decoder_inputs, decoder_targets, labels) in enumerate(tqdm_data):
             latent_codes = model.encoder_forward(*encoder_inputs)
+            labels = model.Linear1(labels)
+            latent_codes = torch.cat((latent_codes, labels), dim=1)
+            latent_codes = model.Linear(latent_codes)
             decoder_outputs, decoder_output_lengths, _ = model.decoder_forward(
                 *decoder_inputs, latent_codes, is_latent_states=True)
 
@@ -65,11 +71,21 @@ class AAETrainer:
         postfix['autoencoder_loss'] = 0
         postfix['generator_loss'] = 0
         postfix['discriminator_loss'] = 0
+        if self.config.conditional_model:
+            postfix['tanimoto_loss'] = 0
 
-        for i, (encoder_inputs, decoder_inputs, decoder_targets) in enumerate(tqdm_data):
+        for i, (encoder_inputs, decoder_inputs, decoder_targets, labels) in enumerate(tqdm_data):
             latent_codes = model.encoder_forward(*encoder_inputs)
-            decoder_outputs, decoder_output_lengths, _ = model.decoder_forward(
-                *decoder_inputs, latent_codes, is_latent_states=True)
+            
+            if self.config.conditional_model:
+                labels_org = labels
+                labels = model.Linear1(labels)
+                latent_z_y = torch.cat((latent_codes,labels),dim=1)
+                latent_z_y = model.Linear(latent_z_y)
+                decoder_outputs, decoder_output_lengths, _ = model.decoder_forward(*decoder_inputs, latent_z_y, is_latent_states=True)
+            else:
+                decoder_outputs, decoder_output_lengths, _ = model.decoder_forward(*decoder_inputs, latent_codes, is_latent_states=True)
+
             discriminator_outputs = model.discriminator_forward(latent_codes)
 
             decoder_outputs = torch.cat([t[:l] for t, l in zip(decoder_outputs, decoder_output_lengths)], dim=0)
@@ -87,23 +103,55 @@ class AAETrainer:
 
             discriminator_loss = criterions['discriminator'](discriminator_outputs, discriminator_targets)
 
+            if self.config.conditional_model:
+                def Tanimoto(l1, l2):
+                    a = sum(l1)
+                    b = sum(l2)
+                    c = sum([int(l1[i])&int(l2[i]) for i in range(len(l1))])
+                    return c/(a+b-c)
+                sim = []
+                if labels_org.shape[0]==self.config.n_batch:
+                    smiles = model.sample(self.config.n_batch, 100, labels_org)
+                    labels_org = labels_org.tolist()
+                    for i in range(self.config.n_batch):
+                        m = Chem.MolFromSmiles(smiles[i])
+                        if m:
+                            keys = MACCSkeys.GenMACCSKeys(m)
+                            fp = np.array(keys)
+                            fp = fp.tolist()
+                            sim.append(Tanimoto(fp,labels_org[i]))
+                        else:
+                            sim.append(0.0)
+
+                tanimoto_loss = criterions['tanimoto'](torch.FloatTensor(sim))
+
             if optimizers is not None:
                 optimizers['autoencoder'].zero_grad()
                 autoencoder_loss.backward(retain_graph=True)
                 optimizers['autoencoder'].step()
 
-                optimizers['generator'].zero_grad()
-                generator_loss.backward(retain_graph=True)
-                optimizers['generator'].step()
+                if discriminator_loss.item() < self.config.g_threshold:
+                    optimizers['generator'].zero_grad()
+                    generator_loss.backward(retain_graph=True)
+                    optimizers['generator'].step()
 
-                optimizers['discriminator'].zero_grad()
-                discriminator_loss.backward()
-                optimizers['discriminator'].step()
+                if discriminator_loss.item() > self.config.d_threshold:
+                    optimizers['discriminator'].zero_grad()
+                    discriminator_loss.backward()
+                    optimizers['discriminator'].step()
+                
+                if self.config.conditional_model and tanimoto_loss.shape:
+                    optimizers['tanimoto'].zero_grad()
+                    tanimoto_loss.backward()
+                    optimizers['tanimoto'].step()
 
             postfix['autoencoder_loss'] = (postfix['autoencoder_loss'] * i + autoencoder_loss.item()) / (i + 1)
             postfix['generator_loss'] = (postfix['generator_loss'] * i + generator_loss.item()) / (i + 1)
             postfix['discriminator_loss'] = (postfix['discriminator_loss'] * i + discriminator_loss.item()) / (i + 1)
-
+            
+            if self.config.conditional_model and tanimoto_loss.item()==tanimoto_loss.item():
+                postfix['tanimoto_loss'] = (postfix['tanimoto_loss'] * i + tanimoto_loss.item()) / (i + 1)
+            
             tqdm_data.set_postfix(postfix)
 
         postfix['mode'] = 'Test' if optimizers is None else 'Eval'
@@ -113,14 +161,23 @@ class AAETrainer:
         self.log_file.flush()
 
     def _train(self, model, train_loader, val_loader=None):
-        criterions = {'autoencoder': nn.CrossEntropyLoss(),
-                      'generator': lambda t: -torch.mean(F.logsigmoid(t)),
-                      'discriminator': nn.BCEWithLogitsLoss()}
 
-        optimizers = {'autoencoder': torch.optim.Adam(list(model.encoder.parameters()) +
-                                                      list(model.decoder.parameters()), lr=self.config.lr),
-                      'generator': torch.optim.Adam(model.encoder.parameters(), lr=self.config.lr),
-                      'discriminator': torch.optim.Adam(model.discriminator.parameters(), lr=self.config.lr)}
+        if self.config.conditional_model:
+            criterions = {'autoencoder': nn.CrossEntropyLoss(),
+                      'generator': lambda t: -torch.mean(F.logsigmoid(t)),
+                      'discriminator': nn.BCEWithLogitsLoss(),
+                      'tanimoto': lambda t: -torch.mean(F.logsigmoid(t))}
+            optimizers = {'autoencoder': torch.optim.Adam(list(model.encoder.parameters()) + list(model.decoder.parameters()), lr=self.config.lr),
+                      'generator': torch.optim.Adam(list(model.encoder.parameters()), lr=self.config.lr),
+                      'discriminator': torch.optim.Adam(model.discriminator.parameters(), lr=self.config.lr),
+                      'tanimoto': torch.optim.Adam(list(model.Linear1.parameters()) + list(model.Linear.parameters()), lr=self.config.lr)}
+        else:
+            criterions = {'autoencoder': nn.CrossEntropyLoss(),
+                    'generator': lambda t: -torch.mean(F.logsigmoid(t)),
+                    'discriminator': nn.BCEWithLogitsLoss()}
+            optimizers = {'autoencoder': torch.optim.Adam(list(model.encoder.parameters()) + list(model.decoder.parameters()), lr=self.config.lr),
+                        'generator': torch.optim.Adam(list(model.encoder.parameters()), lr=self.config.lr),
+                        'discriminator': torch.optim.Adam(model.discriminator.parameters(), lr=self.config.lr)}
         schedulers = {
             k: torch.optim.lr_scheduler.StepLR(v, self.config.step_size, self.config.gamma)
             for k, v in optimizers.items()
@@ -149,9 +206,18 @@ class AAETrainer:
         self.log_file.write(str(model)+'\n')
 
         def collate(data):
-            data.sort(key=lambda x: len(x), reverse=True)
 
-            tensors = [model.string2tensor(string) for string in data]
+            if self.config.conditional_model:
+                data.sort(key=lambda x: len(x[0]), reverse=True)
+                X = [a[0] for a in data]
+                Y = [a[1] for a in data]
+                condition = torch.FloatTensor(Y).cuda()
+            else:
+                data.sort(key=lambda x: len(x), reverse=True)
+                X = [a for a in data]
+                condition = [None for a in data]
+
+            tensors = [model.string2tensor(string) for string in X]
             lengths = torch.tensor([len(t) for t in tensors], dtype=torch.long, device=model.device)
 
             encoder_inputs = pad_sequence(tensors, batch_first=True, padding_value=model.vocabulary.pad)
@@ -167,7 +233,8 @@ class AAETrainer:
 
             return (encoder_inputs, encoder_input_lengths), \
                    (decoder_inputs, decoder_input_lengths), \
-                   (decoder_targets, decoder_target_lengths)
+                   (decoder_targets, decoder_target_lengths), \
+                   (condition)
 
         train_loader = DataLoader(train_data, batch_size=self.config.n_batch, shuffle=True, collate_fn=collate)
         val_loader = None if val_data is None else DataLoader(

--- a/moses/script_utils.py
+++ b/moses/script_utils.py
@@ -44,7 +44,7 @@ def add_train_args(parser):
     common_arg = parser.add_argument_group('Common')
     add_common_arg(common_arg)
     common_arg.add_argument('--train_load',
-                            type=str, required=True,
+                            type=str, default='../../data/data.csv',
                             help='Input data in csv format to train')
     common_arg.add_argument('--model_save',
                             type=str, default='model.pt',
@@ -79,8 +79,8 @@ def add_sample_args(parser):
                             type=str, default='vocab.pt',
                             help='Where to load the vocab')
     common_arg.add_argument('--n_samples',
-                            type=int, required=True,
-                            help='Number of samples to sample')
+                            type=int, default=1000,
+                            help='Number of samples to sample (for each condition)')
     common_arg.add_argument('--gen_save',
                             type=str, default='gen.csv',
                             help='Where to save the gen molecules')
@@ -90,6 +90,12 @@ def add_sample_args(parser):
     common_arg.add_argument("--max_len",
                             type=int, default=100,
                             help="Max of length of SMILES")
+    common_arg.add_argument('--n_labels',
+                            type=int, default=100,
+                            help='Number of labels for sampling')
+    common_arg.add_argument('--label_load',
+                            type=str, default='../../data/molhack_test_1.csv',
+                            help='Where to load the conditions for sampling')
 
     return parser
 
@@ -99,6 +105,8 @@ def read_smiles_csv(path):
                        usecols=['SMILES'],
                        squeeze=True).astype(str).tolist()
 
+def read_label_csv(path):
+    return pd.read_csv(path, usecols=['fingerprints_org'], squeeze=True).astype(str).tolist()
 
 def set_seed(seed):
     torch.manual_seed(seed)

--- a/moses/utils.py
+++ b/moses/utils.py
@@ -74,8 +74,10 @@ class CharVocab:
         if len(ids) == 0:
             return ''
         if rem_bos and ids[0] == self.bos:
+            if len(ids) == 1: return ''
             ids = ids[1:]
         if rem_eos and ids[-1] == self.eos:
+            if len(ids) == 1: return ''
             ids = ids[:-1]
 
         string = ''.join([self.id2char(id) for id in ids])

--- a/scripts/aae/sample.py
+++ b/scripts/aae/sample.py
@@ -1,8 +1,11 @@
 import argparse
 
 import pandas as pd
+import numpy as np
 import torch
 import tqdm
+from rdkit import Chem
+from rdkit.Chem import MACCSkeys
 
 from moses.aae import AAE
 from moses.script_utils import add_sample_args, set_seed
@@ -10,7 +13,6 @@ from moses.script_utils import add_sample_args, set_seed
 
 def get_parser():
     return add_sample_args(argparse.ArgumentParser())
-
 
 def main(config):
     set_seed(config.seed)
@@ -26,18 +28,30 @@ def main(config):
     model = model.to(device)
     model.eval()
 
+    if model_config.conditional_model:
+        test = pd.read_csv(config.label_load,usecols=['fingerprints_center'],squeeze=True).astype(str).tolist()
+        labels = [[int(x) for x in list(t)] for t in test]
+        labels = np.array(labels)
+        labels = torch.FloatTensor(labels).cuda()
+    else: labels = None
+
     samples = []
     n = config.n_samples
-    with tqdm.tqdm(total=config.n_samples, desc='Generating samples') as T:
+    n_labels = config.n_labels
+    with tqdm.tqdm(total=config.n_samples*n_labels, desc='Generating samples') as T:
         while n > 0:
-            current_samples = model.sample(min(n, config.n_batch), config.max_len)
-            samples.extend(current_samples)
+            current_samples = model.sample(n_labels, config.max_len, labels)
+            samples.append(current_samples)
+            n-=1
+            T.update(n_labels)
 
-            n -= len(current_samples)
-            T.update(len(current_samples))
-
-    samples = pd.DataFrame(samples, columns=['SMILES'])
-    samples.to_csv(config.gen_save, index=False)
+    samples = np.transpose(np.array(samples)).tolist()
+    output = open(config.gen_save,'w')
+    output.write('SMILES\n')
+    for i in range(len(samples)):
+        for j in range(len(samples[0])):
+            output.write('{0}\n'.format(samples[i][j]))
+    output.close()
 
 
 if __name__ == '__main__':

--- a/scripts/aae/train.py
+++ b/scripts/aae/train.py
@@ -1,7 +1,8 @@
 import torch
+from random import shuffle
 
 from moses.aae import AAE, AAETrainer, get_parser as aae_parser
-from moses.script_utils import add_train_args, read_smiles_csv, set_seed
+from moses.script_utils import add_train_args, read_smiles_csv, read_label_csv, set_seed
 from moses.utils import CharVocab
 
 
@@ -13,7 +14,15 @@ def main(config):
     set_seed(config.seed)
 
     train = read_smiles_csv(config.train_load)
-
+    if config.conditional_model:
+        labels = read_label_csv(config.train_load)
+        config.labels_size = len(labels[0])
+        labels = [[int(x) for x in list(l)] for l in labels]
+        train_data = [(x, y) for (x,y) in zip(train, labels)]
+    else:
+        train_data = [(x) for x in train]
+    shuffle(train_data)
+    train_data = train_data[:500000]
     vocab = CharVocab.from_data(train)
     torch.save(config, config.config_save)
     torch.save(vocab, config.vocab_save)
@@ -24,7 +33,7 @@ def main(config):
     model = model.to(device)
 
     trainer = AAETrainer(config)
-    trainer.fit(model, train)
+    trainer.fit(model, train_data)
 
     model.to('cpu')
     torch.save(model.state_dict(), config.model_save)


### PR DESCRIPTION
I add a version of conditional aae. Here, the condition is MACCS keys. The condition is embedded and concatenated with the output of encoder. Then, after a fully-connected layer, the vector is taken as the input of decoder (fed as states to RNN model). Also, the loss function is designed to calculate the tanimoto similarity to force the model to learn the condition.

1. Add a switch to choose either conditional or non-conditional (default)
2. Add arguments of the size of the original label and embedded size. If the setting is different from the size read from the file, it will be reset as the same as the size in the file.
3. Add arguments of the thresholds of both discriminator and generator to ensure they are equally strong.
4. Tanimoto loss is added when conditional learning to learn MACCS key.
5. During conditional training, sampling takes places to calculate the Tanimoto loss. It sometimes samples only 'eos' character which results in list index error when accessing ids[-1].