### PR TITLE
Catch ValueError: Sanitization error in compute_scaffold()

### DIFF
--- a/moses/metrics/utils.py
+++ b/moses/metrics/utils.py
@@ -108,7 +108,10 @@ def compute_scaffolds(mol_list, n_jobs=1, min_rings=2):
 
 def compute_scaffold(mol, min_rings=2):
     mol = get_mol(mol)
-    scaffold = MurckoScaffold.GetScaffoldForMol(mol)
+    try:
+        scaffold = MurckoScaffold.GetScaffoldForMol(mol)
+    except:
+        return None
     n_rings = get_n_rings(scaffold)
     scaffold_smiles = Chem.MolToSmiles(scaffold)
     if scaffold_smiles == '' or n_rings < min_rings:


### PR DESCRIPTION
Catch `ValueError: Sanitization error: Explicit valence for atom greater than permitted` as invalid molecule, during call to `compute_scaffold()`.