### PR TITLE
Update sascorer.py

### DIFF
--- a/moses/metrics/SA_Score/sascorer.py
+++ b/moses/metrics/SA_Score/sascorer.py
@@ -24,7 +24,7 @@ import pickle
 
 from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
-from rdkit.six import iteritems
+from six import iteritems
 
 _fscores = None
 


### PR DESCRIPTION
rdkit.six has been replaced with six for newer versions of python